### PR TITLE
material assign subcommand

### DIFF
--- a/doc/docbook/system/mann/CMakeLists.txt
+++ b/doc/docbook/system/mann/CMakeLists.txt
@@ -123,6 +123,7 @@ set(mann_EN
   make_pnts.xml
   man.xml
   mater.xml
+  material.xml
   matpick.xml
   mirface.xml
   mrot.xml

--- a/doc/docbook/system/mann/material.xml
+++ b/doc/docbook/system/mann/material.xml
@@ -1,0 +1,199 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="attr">
+<refmeta>
+  <refentrytitle>ATTR</refentrytitle>
+  <manvolnum>nged</manvolnum>
+  <refmiscinfo class="source">BRL-CAD</refmiscinfo>
+  <refmiscinfo class="manual">BRL-CAD MGED Commands</refmiscinfo>
+</refmeta>
+
+<refnamediv xml:id="name">
+  <refname>material</refname>
+  <refpurpose> Used to create, change, retrieve, assign, import, or view materials and their properties.
+   </refpurpose>
+</refnamediv>
+
+<!-- body begins here -->
+<refsynopsisdiv xml:id="synopsis">
+  <cmdsynopsis sepchar=" ">
+    <command>material assign</command>
+    <arg choice="req" rep="norepeat"><replaceable>object_name_pattern</replaceable></arg>
+    <arg choice="req" rep="norepeat"><replaceable>material_name</replaceable></arg>
+  </cmdsynopsis>
+  <cmdsynopsis sepchar=" ">
+    <command>material create</command>
+    <arg choice="req" rep="norepeat"><replaceable>object_name_pattern</replaceable></arg>
+    <arg choice="req" rep="norepeat"><replaceable>material_name</replaceable></arg>
+  </cmdsynopsis>
+  <cmdsynopsis sepchar=" ">
+    <command>material import</command>
+    <arg choice="opt" rep="norepeat"><replaceable>--id | --name</replaceable></arg>
+    <arg choice="req" rep="norepeat"><replaceable>file_name</replaceable></arg>
+  </cmdsynopsis>
+  <cmdsynopsis sepchar=" ">
+    <command>material get</command>
+    <arg choice="req" rep="norepeat"><replaceable>object_name_pattern</replaceable></arg>
+    <arg choice="opt" rep="norepeat"><replaceable>property_group_name</replaceable></arg>
+    <arg choice="req" rep="norepeat"><replaceable>property_name</replaceable></arg>
+  </cmdsynopsis>
+  <cmdsynopsis sepchar=" ">
+    <command>material remove</command>
+    <arg choice="req" rep="norepeat"><replaceable>object_name_pattern</replaceable></arg>
+    <arg choice="opt" rep="norepeat"><replaceable>property_group_name</replaceable></arg>
+    <arg choice="req" rep="norepeat"><replaceable>property_name</replaceable></arg>
+  </cmdsynopsis>
+  <cmdsynopsis sepchar=" ">
+    <command>material set</command>
+    <arg choice="req" rep="norepeat"><replaceable>object_name_pattern</replaceable></arg>
+    <arg choice="opt" rep="norepeat"><replaceable>property_group_name</replaceable></arg>
+    <arg choice="req" rep="norepeat"><replaceable>property_name</replaceable></arg>
+    <arg choice="req" rep="norepeat"><replaceable>property_value</replaceable></arg>
+  </cmdsynopsis>
+</refsynopsisdiv>
+
+<refsection xml:id="description"><title>DESCRIPTION</title>
+
+  <para>
+    Used to create, change, retrieve, assign, import, or view materials and their properties.
+    Note that properties and property materials are cases sensitive and should not contain whitespace.
+  </para>
+
+  <para>A newly formed material will have a minimum of the following data set on creation:</para>
+  <para>
+  <itemizedlist>
+    <listitem><para>name</para></listitem>
+  </itemizedlist>
+  </para>
+
+  <para>
+    Material objects are made up of a name (seperate from the object name), parent value, and source value. All of which are variable length strings.  
+  </para>
+
+  <para>
+    In addition to the three variable length string properties, material objects also contain four key-value lists used for storing additional material information:
+    <itemizedlist>
+    <listitem><para>physical</para></listitem>
+    <listitem><para>mechanical</para></listitem>
+    <listitem><para>optical</para></listitem>
+    <listitem><para>thermal</para></listitem>
+  </itemizedlist>   
+  </para>
+
+</refsection>
+
+<refsection xml:id="attr_subcommands"><title>SUB-COMMANDS</title>
+
+  <variablelist remap="TP">
+        <varlistentry>
+          <term><emphasis remap="B" role="bold">assign</emphasis></term>
+          <listitem>
+                <para>
+                  Set the material_name property of the specified object to the specified material. Operates similarly to attr set.
+                </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><emphasis remap="B" role="bold">create</emphasis></term>
+          <listitem>
+                <para>
+                  Initalize a new material and sets the name property to the value specified.
+                </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><emphasis remap="B" role="bold">destroy</emphasis></term>
+          <listitem>
+                <para>
+                  Destroy the material object.
+                </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><emphasis remap="B" role="bold">get</emphasis></term>
+          <listitem>
+                <para>
+                  Retrieve a property of the material, optionally from one of the material's four material groups.
+                </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><emphasis remap="B" role="bold">import</emphasis></term>
+          <listitem>
+                <para>
+                  Import a density file's entries into material objects. --id denotes the material object names will be the id of the entry in the density table, --name the name of the
+                  entry in the density file.
+                </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><emphasis remap="B" role="bold">remove</emphasis></term>
+          <listitem>
+                <para>
+                  Remove a material property from the object. (In the case of name, parent, and source this merely sets those values to NULL).
+                </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><emphasis remap="B" role="bold">set</emphasis></term>
+          <listitem>
+                <para>
+                  Set a material property on the object, optionally from one of the material's four material groups.
+                </para>
+          </listitem>
+        </varlistentry>
+  </variablelist>
+
+</refsection>
+
+
+<refsection xml:id="examples"><title>EXAMPLES</title>
+
+  <para>
+    The examples demonstrate the use of the <command>material</command> command and subcommands.
+  </para>
+
+  <example><title>Import a density file to material objects.</title>
+    <variablelist>
+      <varlistentry>
+	<term><prompt>mged&gt;</prompt> <userinput>material import --id .density</userinput></term>
+	<listitem>
+	  <para>
+	    Imports the density file <emphasis>.density</emphasis> to material objects and names the objects based on the file's ids.
+	  </para>
+	</listitem>
+      </varlistentry>
+    </variablelist>
+  </example>
+
+  <example><title>Get the density attribute of the material "copper" within the physical property group.</title>
+    <variablelist>
+      <varlistentry>
+	<term><prompt>mged&gt;</prompt> <userinput>material get copper physical density</userinput></term>
+    <listitem>
+	<para>Outputs the value of density. 
+	</para>
+</listitem>
+      </varlistentry>
+    </variablelist>
+  </example>
+
+</refsection>
+
+<refsection xml:id="author"><title>AUTHOR</title>
+  <para>BRL-CAD Team</para>
+</refsection>
+
+<refsection xml:id="copyright"><title>COPYRIGHT</title>
+    <para>
+      This software is Copyright (c) 2008-2021 United States
+      Government as represented by the U.S. Army Research Laboratory.
+    </para>
+</refsection>
+
+<refsection xml:id="bug_reports"><title>BUG REPORTS</title>
+
+  <para>
+    Reports of bugs or problems should be submitted via electronic
+    mail to <email>devs@brlcad.org</email>
+  </para>
+</refsection>
+</refentry>

--- a/src/libged/material/material.c
+++ b/src/libged/material/material.c
@@ -36,6 +36,7 @@
 #include "wdb.h"
 
 typedef enum {
+    MATERIAL_ASSIGN,
     MATERIAL_CREATE,
     MATERIAL_DESTROY,
     MATERIAL_GET,
@@ -50,6 +51,7 @@ static const char *usage = " help \n\n"
     "material create {objectName} {materialName}\n\n"
     "material destroy {object}\n\n"
     "material import [--id | --name] {fileName}\n\n"
+    "material assign {object} {materialName}\n\n"
     "material get {object} [propertyGroupName] {propertyName}\n\n"
     "material set {object} [propertyGroupName] {propertyName} [newPropertyValue]\n\n"
     "material remove {object} [propertyGroupName] {propertyName}\n\n"
@@ -71,6 +73,7 @@ HIDDEN material_cmd_t
 get_material_cmd(const char* arg)
 {
     /* sub-commands */
+    const char ASSIGN[]   = "assign";
     const char CREATE[]   = "create";
     const char DESTROY[]  = "destroy";
     const char GET[]      = "get";
@@ -80,7 +83,9 @@ get_material_cmd(const char* arg)
     const char SET[]      = "set";
 
     /* alphabetical order */
-    if (BU_STR_EQUIV(CREATE, arg))
+    if (BU_STR_EQUIV(ASSIGN, arg))
+	return MATERIAL_ASSIGN;
+    else if (BU_STR_EQUIV(CREATE, arg))
 	return MATERIAL_CREATE;
     else if (BU_STR_EQUIV(DESTROY, arg))
 	return MATERIAL_DESTROY;
@@ -96,6 +101,44 @@ get_material_cmd(const char* arg)
     return MATERIAL_REMOVE;
     else
     return ATTR_UNKNOWN;
+}
+
+int assign_material(struct ged *gedp, int argc, const char *argv[]) {
+    struct directory *dp;
+    struct bu_attribute_value_set avs;
+    const char * material_name_prop = "material_name";
+
+    if (argc < 4) {
+        bu_vls_printf(gedp->ged_result_str, "you must provide at least four arguments.");
+        return GED_ERROR;
+    }
+
+    GED_CHECK_DATABASE_OPEN(gedp, GED_ERROR);
+    GED_CHECK_DRAWABLE(gedp, GED_ERROR);
+    GED_CHECK_READ_ONLY(gedp, GED_ERROR);
+    GED_CHECK_ARGC_GT_0(gedp, argc, GED_ERROR);
+
+    if ((dp = db_lookup(gedp->dbip,  argv[2], 0)) != RT_DIR_NULL) {
+        bu_avs_init_empty(&avs);
+
+        if (db5_get_attributes(gedp->dbip, &avs, dp)) {
+            bu_vls_printf(gedp->ged_result_str, "Cannot get attributes for object %s\n", dp->d_namep);
+            return GED_ERROR;
+        } else {
+            bu_avs_remove(&avs, material_name_prop);
+            bu_avs_add(&avs, material_name_prop, argv[3]);
+        }
+
+        if (db5_update_attributes(dp, &avs, gedp->dbip)) {
+            bu_vls_printf(gedp->ged_result_str, "Error: failed to update attributes\n");
+            return GED_ERROR;
+        }
+    } else {
+        bu_vls_printf(gedp->ged_result_str, "Cannot get object %s\n", argv[2]);
+        return GED_ERROR;
+    }
+
+    return GED_OK;
 }
 
 // Routine handles the import of a density table
@@ -498,7 +541,11 @@ ged_material_core(struct ged *gedp, int argc, const char *argv[]){
 
     scmd = get_material_cmd(argv[1]);
 
-    if (scmd == MATERIAL_CREATE) {
+    if (scmd == MATERIAL_ASSIGN) {
+        // assign routine
+        assign_material(gedp, argc, argv);
+    }
+    else if (scmd == MATERIAL_CREATE) {
         // create routine
         create_material(gedp, argc, argv);
     } else if (scmd == MATERIAL_DESTROY) {

--- a/src/librt/attributes.c
+++ b/src/librt/attributes.c
@@ -331,8 +331,8 @@ db5_update_attributes(struct directory *dp, struct bu_attribute_value_set *avsp,
 	}
     }
 
+    // set the material_id field using the material given by the material_name field
     const char *material_name = bu_avs_get(avsp, "material_name");
-    const char *material_id = bu_avs_get(&old_avs, "material_id");
     if (material_name != NULL && !BU_STR_EQUAL(material_name, "(null)") && !BU_STR_EQUAL(material_name, "del")) {
         struct directory *material_dp = db_lookup(dbip, material_name, LOOKUP_QUIET);
         if (material_dp != RT_DIR_NULL) {
@@ -342,10 +342,12 @@ db5_update_attributes(struct directory *dp, struct bu_attribute_value_set *avsp,
                 if (intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
                     material_ip = (struct rt_material_internal *) intern.idb_ptr;
                     const char *id_string = bu_avs_get(&material_ip->physicalProperties, "id");
-                    if (id_string == NULL) {
-                        bu_log("WARNING: [%s] has invalid material_name value [%s]\nmaterial_id remains at %s\n", dp->d_namep, material_name, material_id);
-                    } else {
+                    // the material_id will only be set if the material object has an id field set
+                    // otherwise, material_id is set to the default value of 1
+                    if (id_string != NULL) {
                         bu_avs_add(avsp, "material_id", id_string);
+                    } else {
+                        bu_avs_add(avsp, "material_id", "1");
                     }
                 }
             }

--- a/src/tclscripts/mged/help.tcl
+++ b/src/tclscripts/mged/help.tcl
@@ -210,6 +210,22 @@ set mged_help_data(make)	{{-t | name <arb8|arb7|arb6|arb5|arb4|arbn|ars|bot|ehy|
 set mged_help_data(make_pnts)	{{object_name path_and_filename file_format units_or_conv_factor default_diameter} {creates a point-cloud}}
 set mged_help_data(match)	$helplib_data(wdb_match)
 set mged_help_data(mater)	{{comb [material]}	{assign/delete material to combination}}
+set mged_help_data(material)	{{[options]} {Creates materials and allows assigning of properties.
+
+Options:
+	
+import [--id|--name] fileName					-Imports materials from a density table.
+	--id - Specifies that the material will be imported with the id.
+	--name - Specifies that the material will be imported with the name.
+
+create objectName materialName			    	-Stores a material with name db_name.
+
+destroy objectName					    	-Deletes material from database.
+
+set objectName propertyGroup propertyName propertyValue 	-Sets a property in specified group with name and value.
+
+get objectName propertyGroup propertyName		    	-Gets a property value based on name and group.
+	propertyGroup : [physical | mechanical | optical | thermal]}}
 set mged_help_data(matpick)	{{# | a/b}	{select arc which has matrix to be edited, in O_PATH state}}
 set mged_help_data(mirface)	{{#### of axis}	{mirror an ARB face}}
 set mged_help_data(mirror)	{{[-p point] [-d dir] [-x] [-y] [-z] [-o offset] old new}	{mirror primitive or combination along the specified axis}}


### PR DESCRIPTION
Cole: Material assign subcommand,

This will essentially have the same effect as "attr set {objectName} material_name {materialName}" but was added into the material command for continuity with regards to user interaction with material objects.