### PR TITLE
Gqa and rtweight

### DIFF
--- a/src/libged/gqa/gqa.cpp
+++ b/src/libged/gqa/gqa.cpp
@@ -69,6 +69,8 @@ const char *options_str = "[-A A|a|b|c|e|g|m|o|v|w] [-a az] [-d] [-e el] [-f den
 #define ANALYSIS_MOMENTS        512
 #define ANALYSIS_PLOT_OVERLAPS 1024
 
+#define MAX_MATERIAL_ID  32768
+
 /* Note: struct parsing requires no space after the commas.  take care
  * when formatting this file.  if the compile breaks here, it means
  * that spaces got inserted incorrectly.
@@ -1511,59 +1513,6 @@ options_prep(struct rt_i *UNUSED(rtip), vect_t span)
     double newGridSpacing = gridSpacing;
     int axis;
 
-    /* figure out where the density values are coming from and get
-     * them.
-     */
-    if (analysis_flags & ANALYSIS_WEIGHTS) {
-	if (densityFileName) {
-	    DLOG(_ged_current_gedp->ged_result_str, "density from file\n");
-	    if (_ged_read_densities(&_gd_densities, &_gd_densities_source, _ged_current_gedp, densityFileName, 0) != GED_OK) {
-		return GED_ERROR;
-	    }
-	} else {
-	    DLOG(_ged_current_gedp->ged_result_str, "density from db\n");
-	    if (_ged_read_densities(&_gd_densities, &_gd_densities_source, _ged_current_gedp, NULL, 0) != GED_OK) {
-		return GED_ERROR;
-	    }
-	}
-	// iterate through the db and find all materials
-    for (int i = 0; i < RT_DBNHASH; i++) {
-        struct directory *dp = _ged_current_gedp->ged_wdbp->dbip->dbi_Head[i];
-        if (dp != NULL) {
-            struct rt_db_internal intern;
-            struct rt_material_internal *material_ip;
-            if (rt_db_get_internal(&intern, dp, _ged_current_gedp->ged_wdbp->dbip, NULL, &rt_uniresource) >= 0) {
-                if (intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
-                    // if the material has an id and density, add it to the density table
-                    material_ip = (struct rt_material_internal *)intern.idb_ptr;
-
-                    const char *id_string = bu_avs_get(&material_ip->physicalProperties, "id");
-                    if (id_string == NULL) {
-                        continue;
-                    }
-                    int id = strtol(id_string, NULL, 10);
-
-                    const char *density_string = bu_avs_get(&material_ip->physicalProperties, "density");
-                    if (density_string == NULL) {
-                        continue;
-                    }
-                    double density_double = strtod(density_string, NULL);
-                    /* since BRL-CAD does computation in mm, but the table is in
-                    * grams / (cm^3) we convert the table on input
-                    */
-                    density_double = density_double / 1000.0;
-
-                    char *name = bu_vls_strdup(&material_ip->name);
-                    struct bu_vls result_str = BU_VLS_INIT_ZERO;
-                    if (analyze_densities_set(_gd_densities, id, density_double, name, &result_str) < 0) {
-                        bu_vls_printf(&result_str, "Error inserting density %d,%g,%s\n", id, density_double, name);
-                    }
-                    bu_vls_free(&result_str);
-                }
-            }
-        }
-    }
-    }
     /* refine the grid spacing if the user has set a lower bound on
      * the number of rays per model axis
      */
@@ -1688,6 +1637,136 @@ options_prep(struct rt_i *UNUSED(rtip), vect_t span)
     }
 
     return GED_OK;
+}
+
+
+int
+densities_prep(struct db_i *dbip) {
+	analyze_densities_init(_gd_densities);
+	int found_densities = 0;
+
+	/* figure out where the density values are coming from and get
+     * them.
+     */
+    if (analysis_flags & ANALYSIS_WEIGHTS) {
+		if (densityFileName) {
+			DLOG(_ged_current_gedp->ged_result_str, "density from file\n");
+			if (_ged_read_densities(&_gd_densities, &_gd_densities_source, _ged_current_gedp, densityFileName, 0) != GED_OK) {
+				found_densities = 1;
+			}
+		} else {
+			DLOG(_ged_current_gedp->ged_result_str, "density from db\n");
+			if (_ged_read_densities(&_gd_densities, &_gd_densities_source, _ged_current_gedp, NULL, 0) != GED_OK) {
+				found_densities = 1;
+			}
+		}
+
+		// iterate through the db and find all materials
+		int next_available_id = MAX_MATERIAL_ID - 1;
+		for (int i = 0; i < RT_DBNHASH; i++) {
+			struct directory *dp = dbip->dbi_Head[i];
+			if (dp != NULL) {
+				struct rt_db_internal intern;
+				struct rt_material_internal *material_ip;
+				if (dp->d_major_type == DB5_MAJORTYPE_BRLCAD) {
+					if (rt_db_get_internal(&intern, dp, dbip, NULL, &rt_uniresource) >= 0) {
+						if (intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
+							// if the material has a density, add it to the density table
+							material_ip = (struct rt_material_internal *)intern.idb_ptr;
+
+							const char *density_string = bu_avs_get(&material_ip->physicalProperties, "density");
+							if (density_string == NULL) {
+								continue;
+							}
+
+							found_densities = 1;
+							double density_double = strtod(density_string, NULL);
+							/* since BRL-CAD does computation in mm, but the table is in
+							* grams / (cm^3) we convert the table on input
+							*/
+							density_double = density_double / 1000.0;
+
+							const char *id_string = bu_avs_get(&material_ip->physicalProperties, "id");
+							int id;
+							if (id_string == NULL) {
+								// assign id for materials without ids in the density table
+								// start from max material id and work backwards
+								id = next_available_id;
+								next_available_id--;
+							} else {
+								id = strtol(id_string, NULL, 10);
+							}
+
+							char *density_table_name = bu_vls_strdup(&material_ip->name);
+							if (analyze_densities_set(_gd_densities, id, density_double, density_table_name, _ged_current_gedp->ged_result_str) < 0) {
+								bu_vls_printf(_ged_current_gedp->ged_result_str, "Error inserting density %d,%g,%s\n", id, density_double, density_table_name);
+								analyze_densities_clear(_gd_densities);
+								return GED_ERROR;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if (!found_densities) {
+			analyze_densities_clear(_gd_densities);
+			return GED_ERROR;
+		}
+
+		// look for objects with material_name set and set the material_id
+		// analyze_densities_get
+		for (int i = 0; i < RT_DBNHASH; i++) {
+			struct directory *dp = dbip->dbi_Head[i];
+			if (dp != NULL) {
+				if (dp->d_major_type == DB5_MAJORTYPE_BRLCAD) {
+					struct bu_attribute_value_set avs = BU_AVS_INIT_ZERO;
+
+					if (db5_get_attributes(dbip, &avs, dp) == 0) {
+						const char *material_name = bu_avs_get(&avs, "material_name");
+
+						if (material_name != NULL && !BU_STR_EQUAL(material_name, "(null)") && !BU_STR_EQUAL(material_name, "del")) {
+							long int wids[1];
+
+							struct directory *material_dp = db_lookup(dbip, material_name, LOOKUP_QUIET);
+							if (material_dp != NULL) {
+								struct rt_db_internal material_intern;
+								struct rt_material_internal *material_ip;
+								if (rt_db_get_internal(&material_intern, material_dp, dbip, NULL, &rt_uniresource) >= 0) {
+									if (material_intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
+										material_ip = (struct rt_material_internal *)material_intern.idb_ptr;
+										char *density_table_name = bu_vls_strdup(&material_ip->name);
+
+										analyze_densities_id((long int *)wids, 1, _gd_densities, density_table_name);
+
+										struct bu_vls id_vls = BU_VLS_INIT_ZERO;
+										bu_vls_printf(&id_vls, "%ld", wids[0]);
+										char *id_string = bu_vls_strdup(&id_vls);
+										bu_vls_free(&id_vls);
+
+										bu_avs_add(&avs, "material_id", id_string);
+										if (db5_update_attributes(dp, &avs, dbip) != 0) {
+											bu_vls_printf(_ged_current_gedp->ged_result_str, "Error: failed to update attributes\n");
+											analyze_densities_clear(_gd_densities);
+											return GED_ERROR;
+										}
+									}
+								}
+							} else {
+								bu_vls_printf(_ged_current_gedp->ged_result_str, "WARNING: material_name %s is not in the database\n", material_name);
+							}
+						}
+					} else {
+						bu_vls_printf(_ged_current_gedp->ged_result_str, "Error: failed to load attributes\n");
+						analyze_densities_clear(_gd_densities);
+						return GED_ERROR;
+					}
+				}
+			}
+		}
+	}
+
+	return GED_OK;
 }
 
 
@@ -2388,6 +2467,8 @@ ged_gqa_core(struct ged *gedp, int argc, const char *argv[])
 	ged_gqa_plot.vbp = bv_vlblock_init(&RTG.rtg_vlfree, 32);
 	ged_gqa_plot.vhead = bv_vlblock_find(ged_gqa_plot.vbp, 0xFF, 0xFF, 0x00);
     }
+
+	if (densities_prep(gedp->dbip) != GED_OK) return GED_ERROR;
 
     rtip = rt_new_rti(gedp->dbip);
     rtip->useair = use_air;

--- a/src/libged/gqa/gqa.cpp
+++ b/src/libged/gqa/gqa.cpp
@@ -1641,7 +1641,8 @@ options_prep(struct rt_i *UNUSED(rtip), vect_t span)
 
 
 int
-densities_prep(struct db_i *dbip) {
+densities_prep(struct db_i *dbip)
+{
 	analyze_densities_init(_gd_densities);
 	int found_densities = 0;
 
@@ -1672,7 +1673,7 @@ densities_prep(struct db_i *dbip) {
 					if (rt_db_get_internal(&intern, dp, dbip, NULL, &rt_uniresource) >= 0) {
 						if (intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
 							// if the material has a density, add it to the density table
-							material_ip = (struct rt_material_internal *)intern.idb_ptr;
+							material_ip = (struct rt_material_internal *) intern.idb_ptr;
 
 							const char *density_string = bu_avs_get(&material_ip->physicalProperties, "density");
 							if (density_string == NULL) {
@@ -1690,7 +1691,7 @@ densities_prep(struct db_i *dbip) {
 							int id;
 							if (id_string == NULL) {
 								// assign id for materials without ids in the density table
-								// start from max material id and work backwards
+								// start from the max material id and work backwards
 								id = next_available_id;
 								next_available_id--;
 							} else {
@@ -1726,17 +1727,20 @@ densities_prep(struct db_i *dbip) {
 						const char *material_name = bu_avs_get(&avs, "material_name");
 
 						if (material_name != NULL && !BU_STR_EQUAL(material_name, "(null)") && !BU_STR_EQUAL(material_name, "del")) {
-							long int wids[1];
-
 							struct directory *material_dp = db_lookup(dbip, material_name, LOOKUP_QUIET);
+
 							if (material_dp != NULL) {
 								struct rt_db_internal material_intern;
 								struct rt_material_internal *material_ip;
 								if (rt_db_get_internal(&material_intern, material_dp, dbip, NULL, &rt_uniresource) >= 0) {
 									if (material_intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
-										material_ip = (struct rt_material_internal *)material_intern.idb_ptr;
+										// the material_ip->name field is the name in the density table
+										// not just the material_name (they could be different)
+										material_ip = (struct rt_material_internal *) material_intern.idb_ptr;
 										char *density_table_name = bu_vls_strdup(&material_ip->name);
+										long int wids[1];
 
+										// get the id from the density table
 										analyze_densities_id((long int *)wids, 1, _gd_densities, density_table_name);
 
 										struct bu_vls id_vls = BU_VLS_INIT_ZERO;
@@ -1744,9 +1748,10 @@ densities_prep(struct db_i *dbip) {
 										char *id_string = bu_vls_strdup(&id_vls);
 										bu_vls_free(&id_vls);
 
+										// update attributes will set the reg_gmater field on the region
 										bu_avs_add(&avs, "material_id", id_string);
 										if (db5_update_attributes(dp, &avs, dbip) != 0) {
-											bu_vls_printf(_ged_current_gedp->ged_result_str, "Error: failed to update attributes\n");
+											bu_vls_printf(_ged_current_gedp->ged_result_str, "Error: failed to update attributes for %s\n", dp->d_namep);
 											analyze_densities_clear(_gd_densities);
 											return GED_ERROR;
 										}
@@ -1757,7 +1762,7 @@ densities_prep(struct db_i *dbip) {
 							}
 						}
 					} else {
-						bu_vls_printf(_ged_current_gedp->ged_result_str, "Error: failed to load attributes\n");
+						bu_vls_printf(_ged_current_gedp->ged_result_str, "Error: failed to load attributes for %s\n", dp->d_namep);
 						analyze_densities_clear(_gd_densities);
 						return GED_ERROR;
 					}

--- a/src/libged/material/material.c
+++ b/src/libged/material/material.c
@@ -106,7 +106,6 @@ get_material_cmd(const char* arg)
 int assign_material(struct ged *gedp, int argc, const char *argv[]) {
     struct directory *dp;
     struct bu_attribute_value_set avs;
-    const char * material_name_prop = "material_name";
 
     if (argc < 4) {
         bu_vls_printf(gedp->ged_result_str, "you must provide at least four arguments.");
@@ -125,8 +124,8 @@ int assign_material(struct ged *gedp, int argc, const char *argv[]) {
             bu_vls_printf(gedp->ged_result_str, "Cannot get attributes for object %s\n", dp->d_namep);
             return GED_ERROR;
         } else {
-            bu_avs_remove(&avs, material_name_prop);
-            bu_avs_add(&avs, material_name_prop, argv[3]);
+            bu_avs_add(&avs, "material_name", argv[3]);
+            bu_avs_add(&avs, "material_id", "1");
         }
 
         if (db5_update_attributes(dp, &avs, gedp->dbip)) {
@@ -544,8 +543,7 @@ ged_material_core(struct ged *gedp, int argc, const char *argv[]){
     if (scmd == MATERIAL_ASSIGN) {
         // assign routine
         assign_material(gedp, argc, argv);
-    }
-    else if (scmd == MATERIAL_CREATE) {
+    } else if (scmd == MATERIAL_CREATE) {
         // create routine
         create_material(gedp, argc, argv);
     } else if (scmd == MATERIAL_DESTROY) {

--- a/src/libged/material/material.c
+++ b/src/libged/material/material.c
@@ -36,6 +36,7 @@
 #include "wdb.h"
 
 typedef enum {
+    MATERIAL_ASSIGN,
     MATERIAL_CREATE,
     MATERIAL_DESTROY,
     MATERIAL_GET,
@@ -50,6 +51,7 @@ static const char *usage = " help \n\n"
     "material create {objectName} {materialName}\n\n"
     "material destroy {object}\n\n"
     "material import [--id | --name] {fileName}\n\n"
+    "material assign {object} {materialName}\n\n"
     "material get {object} [propertyGroupName] {propertyName}\n\n"
     "material set {object} [propertyGroupName] {propertyName} [newPropertyValue]\n\n"
     "material remove {object} [propertyGroupName] {propertyName}\n\n"
@@ -71,6 +73,7 @@ HIDDEN material_cmd_t
 get_material_cmd(const char* arg)
 {
     /* sub-commands */
+    const char ASSIGN[]   = "assign";
     const char CREATE[]   = "create";
     const char DESTROY[]  = "destroy";
     const char GET[]      = "get";
@@ -80,7 +83,9 @@ get_material_cmd(const char* arg)
     const char SET[]      = "set";
 
     /* alphabetical order */
-    if (BU_STR_EQUIV(CREATE, arg))
+    if (BU_STR_EQUIV(ASSIGN, arg))
+	return MATERIAL_ASSIGN;
+    else if (BU_STR_EQUIV(CREATE, arg))
 	return MATERIAL_CREATE;
     else if (BU_STR_EQUIV(DESTROY, arg))
 	return MATERIAL_DESTROY;
@@ -96,6 +101,44 @@ get_material_cmd(const char* arg)
     return MATERIAL_REMOVE;
     else
     return ATTR_UNKNOWN;
+}
+
+int assign_material(struct ged *gedp, int argc, const char *argv[]) {
+    struct directory *dp;
+    struct bu_attribute_value_set avs;
+    const char * material_name_prop = "material_name";
+
+    if (argc < 4) {
+        bu_vls_printf(gedp->ged_result_str, "you must provide at least four arguments.");
+        return GED_ERROR;
+    }
+
+    GED_CHECK_DATABASE_OPEN(gedp, GED_ERROR);
+    GED_CHECK_DRAWABLE(gedp, GED_ERROR);
+    GED_CHECK_READ_ONLY(gedp, GED_ERROR);
+    GED_CHECK_ARGC_GT_0(gedp, argc, GED_ERROR);
+
+    if ((dp = db_lookup(gedp->dbip,  argv[2], 0)) != RT_DIR_NULL) {
+        bu_avs_init_empty(&avs);
+
+        if (db5_get_attributes(gedp->dbip, &avs, dp)) {
+            bu_vls_printf(gedp->ged_result_str, "Cannot get attributes for object %s\n", dp->d_namep);
+            return GED_ERROR;
+        } else {
+            bu_avs_remove(&avs, material_name_prop);
+            bu_avs_add(&avs, material_name_prop, argv[3]);
+        }
+
+        if (db5_update_attributes(dp, &avs, gedp->dbip)) {
+            bu_vls_printf(gedp->ged_result_str, "Error: failed to update attributes\n");
+            return GED_ERROR;
+        }
+    } else {
+        bu_vls_printf(gedp->ged_result_str, "Cannot get object %s\n", argv[2]);
+        return GED_ERROR;
+    }
+
+    return GED_OK;
 }
 
 // Routine handles the import of a density table
@@ -498,7 +541,11 @@ ged_material_core(struct ged *gedp, int argc, const char *argv[]){
 
     scmd = get_material_cmd(argv[1]);
 
-    if (scmd == MATERIAL_CREATE) {
+    if (scmd == MATERIAL_ASSIGN) {
+        // assign routine
+        assign_material(gedp, argc, argv);
+    }
+    else if (scmd == MATERIAL_CREATE) {
         // create routine
         create_material(gedp, argc, argv);
     } else if (scmd == MATERIAL_DESTROY) {

--- a/src/librt/attributes.c
+++ b/src/librt/attributes.c
@@ -343,11 +343,8 @@ db5_update_attributes(struct directory *dp, struct bu_attribute_value_set *avsp,
                     material_ip = (struct rt_material_internal *) intern.idb_ptr;
                     const char *id_string = bu_avs_get(&material_ip->physicalProperties, "id");
                     // the material_id will only be set if the material object has an id field set
-                    // otherwise, material_id is set to the default value of 1
                     if (id_string != NULL) {
                         bu_avs_add(avsp, "material_id", id_string);
-                    } else {
-                        bu_avs_add(avsp, "material_id", "1");
                     }
                 }
             }

--- a/src/librt/attributes.c
+++ b/src/librt/attributes.c
@@ -331,8 +331,8 @@ db5_update_attributes(struct directory *dp, struct bu_attribute_value_set *avsp,
 	}
     }
 
+    // set the material_id field using the material given by the material_name field
     const char *material_name = bu_avs_get(avsp, "material_name");
-    const char *material_id = bu_avs_get(&old_avs, "material_id");
     if (material_name != NULL && !BU_STR_EQUAL(material_name, "(null)") && !BU_STR_EQUAL(material_name, "del")) {
         struct directory *material_dp = db_lookup(dbip, material_name, LOOKUP_QUIET);
         if (material_dp != RT_DIR_NULL) {
@@ -342,10 +342,12 @@ db5_update_attributes(struct directory *dp, struct bu_attribute_value_set *avsp,
                 if (intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
                     material_ip = (struct rt_material_internal *) intern.idb_ptr;
                     const char *id_string = bu_avs_get(&material_ip->physicalProperties, "id");
-                    if (id_string == NULL) {
-                        bu_log("WARNING: [%s] has invalid material_name value [%s]\nmaterial_id remains at %s\n", dp->d_namep, material_name, material_id);
-                    } else {
+                    // the material_id will only be set if the material object has an id field set
+                    // otherwise, material_id is set to the default value of 1
+                    if (id_string != NULL) {
                         bu_avs_add(avsp, "material_id", id_string);
+                    } else {
+                        bu_avs_add(avsp, "material_id", "1");
                     }
                 }
             }

--- a/src/rt/main.c
+++ b/src/rt/main.c
@@ -455,19 +455,19 @@ int main(int argc, char *argv[])
     memory_summary();
 
     /* Copy values from command line options into rtip */
-    rtip->rti_space_partition = space_partition;
-    rtip->useair = use_air;
-    rtip->rti_save_overlaps = save_overlaps;
+    APP.a_rt_i->rti_space_partition = space_partition;
+    APP.a_rt_i->useair = use_air;
+    APP.a_rt_i->rti_save_overlaps = save_overlaps;
     if (rt_dist_tol > 0)  {
-	rtip->rti_tol.dist = rt_dist_tol;
-	rtip->rti_tol.dist_sq = rt_dist_tol * rt_dist_tol;
+	APP.a_rt_i->rti_tol.dist = rt_dist_tol;
+	APP.a_rt_i->rti_tol.dist_sq = rt_dist_tol * rt_dist_tol;
     }
     if (rt_perp_tol > 0)  {
-	rtip->rti_tol.perp = rt_perp_tol;
-	rtip->rti_tol.para = 1 - rt_perp_tol;
+	APP.a_rt_i->rti_tol.perp = rt_perp_tol;
+	APP.a_rt_i->rti_tol.para = 1 - rt_perp_tol;
     }
     if (rt_verbosity & VERBOSE_TOLERANCE)
-	rt_pr_tol( &rtip->rti_tol);
+	rt_pr_tol(&APP.a_rt_i->rti_tol);
 
     /* before view_init */
     if (outputfile && BU_STR_EQUAL(outputfile, "-"))
@@ -498,7 +498,7 @@ int main(int argc, char *argv[])
      */
     memset(resource, 0, sizeof(resource));
     for (i = 0; i < MAX_PSW; i++) {
-	rt_init_resource(&resource[i], i, rtip);
+	rt_init_resource(&resource[i], i, APP.a_rt_i);
     }
     memory_summary();
 
@@ -538,7 +538,7 @@ int main(int argc, char *argv[])
 	}
 #endif
 
-	def_tree(rtip);		/* Load the default trees */
+	def_tree(APP.a_rt_i);		/* Load the default trees */
 	/* orientation command has not been used */
 	if (!orientflag)
 	    do_ae(azimuth, elevation);
@@ -596,7 +596,7 @@ int main(int argc, char *argv[])
 #endif
 	    }
 
-	    nret = rt_do_cmd( rtip, buf, rt_do_tab);
+	    nret = rt_do_cmd( APP.a_rt_i, buf, rt_do_tab);
 	    bu_free( buf, "rt_read_cmd command buffer");
 	    if (nret < 0)
 		break;
@@ -634,8 +634,8 @@ rt_cleanup:
     }
 
     /* Release the ray-tracer instance */
-    rt_free_rti(rtip);
-    rtip = NULL;
+    rt_free_rti(APP.a_rt_i);
+    APP.a_rt_i = NULL;
 
 #ifdef MPI_ENABLED
     MPI_Finalize();

--- a/src/rt/viewweight.c
+++ b/src/rt/viewweight.c
@@ -66,6 +66,8 @@ int noverlaps = 0;
 FILE *densityfp;
 #define DENSITY_FILE ".density"
 
+#define MAX_MATERIAL_ID  32768
+
 struct analyze_densities *density = NULL;
 
 struct datapoint {
@@ -83,6 +85,266 @@ extern FILE *outfp;          	/* optional output file */
 extern char *outputfile;     	/* name of base of output file */
 extern char *densityfile;     	/* name of density file */
 extern int output_is_binary;	/* !0 means output is binary */
+
+
+// by default, rt opens the rt_i as read only so we need a way to write the
+// material_id field back onto the regions that have the material_name field set
+struct rt_i *
+densities_prep(const char *filename, int minus_o)
+{
+	register struct rt_i *rtip;
+    register struct db_i *dbip;		/* Database instance ptr */
+
+    if (rt_uniresource.re_magic == 0)
+	rt_init_resource(&rt_uniresource, 0, NULL);
+
+	// open a read/write database pointer
+    if ((dbip = db_open(filename, DB_OPEN_READWRITE)) == DBI_NULL)
+	return RTI_NULL;		/* FAIL */
+    RT_CK_DBI(dbip);
+
+    if (db_dirbuild(dbip) < 0) {
+	db_close(dbip);
+	return RTI_NULL;		/* FAIL */
+    }
+
+	// we will return this later if everything goes okay
+    rtip = rt_new_rti(dbip);		/* clones dbip */
+    db_close(dbip);				/* releases original dbip */
+
+    struct bu_vls pbuff_msgs = BU_VLS_INIT_ZERO;
+    struct bu_mapped_file *dfile = NULL;
+    char *dbuff = NULL;
+
+    if (!minus_o) {
+	outfp = stdout;
+	output_is_binary = 0;
+    } else {
+	if (outfp == NULL && outputfile != NULL && strlen(outputfile) > 0)
+	    outfp = fopen(outputfile, "w");
+    }
+
+    if (outfp == NULL && outputfile != NULL && strlen(outputfile) > 0) {
+	bu_log("Unable to open output file \"%s\" for writing\n", outputfile);
+	goto densities_prep_rtweight_fail;
+    }
+
+    if (analyze_densities_create(&density)) {
+	bu_log("INTERNAL ERROR: Unable to initialize density table\n");
+    }
+
+    /* densityfile is global to this file and will be used later (and then freed) */
+    if (densityfile) {
+	if (!bu_file_exists(densityfile, NULL)) {
+	    bu_log("Unable to load density file \"%s\" for reading\n", densityfile);
+	    goto densities_prep_rtweight_fail;
+	}
+
+	dfile = bu_open_mapped_file(densityfile, "densities file");
+	if (!dfile) {
+	    bu_log("Unable to open density file \"%s\" for reading\n", densityfile);
+	    goto densities_prep_rtweight_fail;
+	}
+
+	dbuff = (char *)(dfile->buf);
+
+
+	/* Read in density */
+	if (analyze_densities_load(density, dbuff, &pbuff_msgs, NULL) ==  0) {
+	    bu_log("Unable to parse density file \"%s\":%s\n", densityfile, bu_vls_cstr(&pbuff_msgs));
+	    bu_close_mapped_file(dfile);
+	    goto densities_prep_rtweight_fail;
+	}
+	bu_close_mapped_file(dfile);
+
+
+    } else {
+
+	/* If we don't have a density file, first try the .g itself */
+	struct directory *dp;
+	dp = db_lookup(rtip->rti_dbip, "_DENSITIES", LOOKUP_QUIET);
+	if (dp != (struct directory *)NULL) {
+	    int ret, ecnt;
+	    char *buf;
+	    struct rt_db_internal intern;
+	    struct rt_binunif_internal *bip;
+	    struct bu_vls msgs = BU_VLS_INIT_ZERO;
+	    if (rt_db_get_internal(&intern, dp, rtip->rti_dbip, NULL, &rt_uniresource) < 0) {
+		bu_log("Could not import %s\n", dp->d_namep);
+		goto densities_prep_rtweight_fail;
+	    }
+	    if ((intern.idb_major_type & DB5_MAJORTYPE_BINARY_MASK) == 0)
+		goto densities_prep_rtweight_fail;
+
+	    bip = (struct rt_binunif_internal *)intern.idb_ptr;
+	    RT_CHECK_BINUNIF (bip);
+
+	    buf = (char *)bu_calloc(bip->count+1, sizeof(char), "density buffer");
+	    memcpy(buf, bip->u.int8, bip->count);
+	    rt_db_free_internal(&intern);
+
+	    ret = analyze_densities_load(density, buf, &msgs, &ecnt);
+
+	    bu_free((void *)buf, "density buffer");
+
+	    if (ret <= 0) {
+		bu_log("Problem reading densities from .g file:\n%s\n", bu_vls_cstr(&msgs));
+		bu_vls_free(&msgs);
+		goto densities_prep_rtweight_fail;
+	    }
+
+	    /* found a density table, so record the .g file */
+	    densityfile = rtip->rti_dbip->dbi_filename;
+
+	} else {
+	    static char densityfile_buf[MAXPATHLEN] = {0};
+
+	    /* If we still don't have density information, fall back
+	     * on pre-defined defaults.
+	     */
+	    bu_dir(densityfile_buf, MAXPATHLEN, BU_DIR_CURR, DENSITY_FILE, NULL);
+	    densityfile = densityfile_buf;
+
+	    if (!bu_file_exists(densityfile, NULL)) {
+		bu_dir(densityfile_buf, MAXPATHLEN, BU_DIR_HOME, DENSITY_FILE, NULL);
+		densityfile = densityfile_buf;
+		if (!bu_file_exists(densityfile, NULL)) {
+		    bu_log("Unable to load density file \"%s\" for reading\n", densityfile);
+		    goto densities_prep_rtweight_fail;
+		}
+	    }
+	    dfile = bu_open_mapped_file(densityfile, "densities file");
+	    if (!dfile) {
+		bu_log("Unable to open density file \"%s\" for reading\n", densityfile);
+		goto densities_prep_rtweight_fail;
+	    }
+
+	    dbuff = (char *)(dfile->buf);
+
+
+	    /* Read in density */
+	    if (analyze_densities_load(density, dbuff, &pbuff_msgs, NULL) ==  0) {
+		bu_log("Unable to parse density file \"%s\":%s\n", densityfile, bu_vls_cstr(&pbuff_msgs));
+		bu_close_mapped_file(dfile);
+		goto densities_prep_rtweight_fail;
+	    }
+	    bu_close_mapped_file(dfile);
+	}
+    }
+
+    // iterate through the db and find all materials
+	int next_available_id = MAX_MATERIAL_ID - 1;
+	for (int i = 0; i < RT_DBNHASH; i++) {
+		struct directory *dp = rtip->rti_dbip->dbi_Head[i];
+		if (dp != NULL) {
+			struct rt_db_internal intern;
+			struct rt_material_internal *material_ip;
+			if (dp->d_major_type == DB5_MAJORTYPE_BRLCAD) {
+				if (rt_db_get_internal(&intern, dp, rtip->rti_dbip, NULL, &rt_uniresource) >= 0) {
+					if (intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
+						// if the material has a density, add it to the density table
+						material_ip = (struct rt_material_internal *) intern.idb_ptr;
+
+						const char *density_string = bu_avs_get(&material_ip->physicalProperties, "density");
+						if (density_string == NULL) {
+							continue;
+						}
+
+						double density_double = strtod(density_string, NULL);
+						/* since BRL-CAD does computation in mm, but the table is in
+						* grams / (cm^3) we convert the table on input
+						*/
+						density_double = density_double / 1000.0;
+
+						const char *id_string = bu_avs_get(&material_ip->physicalProperties, "id");
+						int id;
+						if (id_string == NULL) {
+							// assign id for materials without ids in the density table
+							// start from the max material id and work backwards
+							id = next_available_id;
+							next_available_id--;
+						} else {
+							id = strtol(id_string, NULL, 10);
+						}
+
+						char *density_table_name = bu_vls_strdup(&material_ip->name);
+						if (analyze_densities_set(density, id, density_double, density_table_name, &pbuff_msgs) < 0) {
+							bu_log("Error inserting density %d,%g,%s\n", id, density_double, density_table_name);
+							goto densities_prep_rtweight_fail;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// look for objects with material_name set and set the material_id
+	for (int i = 0; i < RT_DBNHASH; i++) {
+		struct directory *dp = rtip->rti_dbip->dbi_Head[i];
+		if (dp != NULL) {
+			if (dp->d_major_type == DB5_MAJORTYPE_BRLCAD) {
+				struct bu_attribute_value_set avs = BU_AVS_INIT_ZERO;
+
+				if (db5_get_attributes(rtip->rti_dbip, &avs, dp) == 0) {
+					const char *material_name = bu_avs_get(&avs, "material_name");
+
+					if (material_name != NULL && !BU_STR_EQUAL(material_name, "(null)") && !BU_STR_EQUAL(material_name, "del")) {
+						struct directory *material_dp = db_lookup(rtip->rti_dbip, material_name, LOOKUP_QUIET);
+
+						if (material_dp != NULL) {
+							struct rt_db_internal material_intern;
+							struct rt_material_internal *material_ip;
+							if (rt_db_get_internal(&material_intern, material_dp, rtip->rti_dbip, NULL, &rt_uniresource) >= 0) {
+								if (material_intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
+									// the material_ip->name field is the name in the density table
+									// not just the material_name (they could be different)
+									material_ip = (struct rt_material_internal *) material_intern.idb_ptr;
+									char *density_table_name = bu_vls_strdup(&material_ip->name);
+									long int wids[1];
+
+									// get the id from the density table
+									analyze_densities_id((long int *)wids, 1, density, density_table_name);
+
+									struct bu_vls id_vls = BU_VLS_INIT_ZERO;
+									bu_vls_printf(&id_vls, "%ld", wids[0]);
+									char *id_string = bu_vls_strdup(&id_vls);
+									bu_vls_free(&id_vls);
+
+									// update attributes will set the reg_gmater field on the region
+									bu_avs_add(&avs, "material_id", id_string);
+									if (db5_update_attributes(dp, &avs, rtip->rti_dbip) != 0) {
+										bu_log("Error: failed to update attributes for %s\n", dp->d_namep);
+										goto densities_prep_rtweight_fail;
+									}
+								}
+							}
+						} else {
+							bu_log("WARNING: material_name %s is not in the database\n", material_name);
+						}
+					}
+				} else {
+					bu_log("Error: failed to load attributes for %s\n", dp->d_namep);
+					goto densities_prep_rtweight_fail;
+				}
+			}
+		}
+	}
+
+	bu_vls_free(&pbuff_msgs);
+    if (minus_o) {
+	fclose(outfp);
+    }
+	return rtip;
+
+densities_prep_rtweight_fail:
+    bu_vls_free(&pbuff_msgs);
+    analyze_densities_destroy(density);
+    if (minus_o && outfp) {
+	fclose(outfp);
+    }
+
+    bu_exit(-1, NULL);
+}
 
 
 static int
@@ -182,186 +444,30 @@ overlap(struct application *UNUSED(ap), struct partition *UNUSED(pp), struct reg
  * Returns 1 if framebuffer should be opened, else 0.
  */
 int
-view_init(struct application *ap, char *UNUSED(file), char *UNUSED(obj), int minus_o, int UNUSED(minus_F))
+view_init(struct application *ap, char *file, char *UNUSED(obj), int minus_o, int UNUSED(minus_F))
 {
-    struct bu_vls pbuff_msgs = BU_VLS_INIT_ZERO;
-    struct bu_mapped_file *dfile = NULL;
-    char *dbuff = NULL;
+	// we need to be able to read/write to the rt_i
+	struct rt_i *rtip = densities_prep(file, minus_o);
 
-    if (!minus_o) {
-	outfp = stdout;
-	output_is_binary = 0;
-    } else {
-	if (outfp == NULL && outputfile != NULL && strlen(outputfile) > 0)
-	    outfp = fopen(outputfile, "w");
-    }
+	// copy the old values possibly set in main before view_init was called
+	rtip->rti_space_partition = APP.a_rt_i->rti_space_partition;
+    rtip->useair = APP.a_rt_i->useair;
+    rtip->rti_save_overlaps = APP.a_rt_i->rti_save_overlaps;
+	rtip->rti_tol.dist = APP.a_rt_i->rti_tol.dist;
+	rtip->rti_tol.dist_sq = APP.a_rt_i->rti_tol.dist_sq;
+	rtip->rti_tol.perp = APP.a_rt_i->rti_tol.perp;
+	rtip->rti_tol.para = APP.a_rt_i->rti_tol.para;
 
-    if (outfp == NULL && outputfile != NULL && strlen(outputfile) > 0) {
-	bu_log("Unable to open output file \"%s\" for writing\n", outputfile);
-	goto view_init_rtweight_fail;
-    }
-
-    if (analyze_densities_create(&density)) {
-	bu_log("INTERNAL ERROR: Unable to initialize density table\n");
-    }
-
-    /* densityfile is global to this file and will be used later (and then freed) */
-    if (densityfile) {
-	if (!bu_file_exists(densityfile, NULL)) {
-	    bu_log("Unable to load density file \"%s\" for reading\n", densityfile);
-	    goto view_init_rtweight_fail;
-	}
-
-	dfile = bu_open_mapped_file(densityfile, "densities file");
-	if (!dfile) {
-	    bu_log("Unable to open density file \"%s\" for reading\n", densityfile);
-	    goto view_init_rtweight_fail;
-	}
-
-	dbuff = (char *)(dfile->buf);
-
-
-	/* Read in density */
-	if (analyze_densities_load(density, dbuff, &pbuff_msgs, NULL) ==  0) {
-	    bu_log("Unable to parse density file \"%s\":%s\n", densityfile, bu_vls_cstr(&pbuff_msgs));
-	    bu_close_mapped_file(dfile);
-	    goto view_init_rtweight_fail;
-	}
-	bu_close_mapped_file(dfile);
-
-
-    } else {
-
-	/* If we don't have a density file, first try the .g itself */
-	struct directory *dp;
-	dp = db_lookup(ap->a_rt_i->rti_dbip, "_DENSITIES", LOOKUP_QUIET);
-	if (dp != (struct directory *)NULL) {
-	    int ret, ecnt;
-	    char *buf;
-	    struct rt_db_internal intern;
-	    struct rt_binunif_internal *bip;
-	    struct bu_vls msgs = BU_VLS_INIT_ZERO;
-	    if (rt_db_get_internal(&intern, dp, ap->a_rt_i->rti_dbip, NULL, &rt_uniresource) < 0) {
-		bu_log("Could not import %s\n", dp->d_namep);
-		goto view_init_rtweight_fail;
-	    }
-	    if ((intern.idb_major_type & DB5_MAJORTYPE_BINARY_MASK) == 0)
-		goto view_init_rtweight_fail;
-
-	    bip = (struct rt_binunif_internal *)intern.idb_ptr;
-	    RT_CHECK_BINUNIF (bip);
-
-	    buf = (char *)bu_calloc(bip->count+1, sizeof(char), "density buffer");
-	    memcpy(buf, bip->u.int8, bip->count);
-	    rt_db_free_internal(&intern);
-
-	    ret = analyze_densities_load(density, buf, &msgs, &ecnt);
-
-	    bu_free((void *)buf, "density buffer");
-
-	    if (ret <= 0) {
-		bu_log("Problem reading densities from .g file:\n%s\n", bu_vls_cstr(&msgs));
-		bu_vls_free(&msgs);
-		goto view_init_rtweight_fail;
-	    }
-
-	    /* found a density table, so record the .g file */
-	    densityfile = ap->a_rt_i->rti_dbip->dbi_filename;
-
-	} else {
-	    static char densityfile_buf[MAXPATHLEN] = {0};
-
-	    /* If we still don't have density information, fall back
-	     * on pre-defined defaults.
-	     */
-	    bu_dir(densityfile_buf, MAXPATHLEN, BU_DIR_CURR, DENSITY_FILE, NULL);
-	    densityfile = densityfile_buf;
-
-	    if (!bu_file_exists(densityfile, NULL)) {
-		bu_dir(densityfile_buf, MAXPATHLEN, BU_DIR_HOME, DENSITY_FILE, NULL);
-		densityfile = densityfile_buf;
-		if (!bu_file_exists(densityfile, NULL)) {
-		    bu_log("Unable to load density file \"%s\" for reading\n", densityfile);
-		    goto view_init_rtweight_fail;
-		}
-	    }
-	    dfile = bu_open_mapped_file(densityfile, "densities file");
-	    if (!dfile) {
-		bu_log("Unable to open density file \"%s\" for reading\n", densityfile);
-		goto view_init_rtweight_fail;
-	    }
-
-	    dbuff = (char *)(dfile->buf);
-
-
-	    /* Read in density */
-	    if (analyze_densities_load(density, dbuff, &pbuff_msgs, NULL) ==  0) {
-		bu_log("Unable to parse density file \"%s\":%s\n", densityfile, bu_vls_cstr(&pbuff_msgs));
-		bu_close_mapped_file(dfile);
-		goto view_init_rtweight_fail;
-	    }
-	    bu_close_mapped_file(dfile);
-	}
-    }
-
-    // iterate through the db and find all materials
-    for (int i = 0; i < RT_DBNHASH; i++) {
-        struct directory *dp = ap->a_rt_i->rti_dbip->dbi_Head[i];
-        if (dp != NULL) {
-            struct rt_db_internal intern;
-            struct rt_material_internal *material_ip;
-            if (rt_db_get_internal(&intern, dp, ap->a_rt_i->rti_dbip, NULL, &rt_uniresource) >= 0) {
-                if (intern.idb_minor_type == DB5_MINORTYPE_BRLCAD_MATERIAL) {
-                    // if the material has an id and density, add it to the density table
-                    material_ip = (struct rt_material_internal *)intern.idb_ptr;
-
-                    const char *id_string = bu_avs_get(&material_ip->physicalProperties, "id");
-                    if (id_string == NULL) {
-                        continue;
-                    }
-                    int id = strtol(id_string, NULL, 10);
-
-                    const char *density_string = bu_avs_get(&material_ip->physicalProperties, "density");
-                    if (density_string == NULL) {
-                        continue;
-                    }
-                    double density_double = strtod(density_string, NULL);
-                    /* since BRL-CAD does computation in mm, but the table is in
-                    * grams / (cm^3) we convert the table on input
-                    */
-                    density_double = density_double / 1000.0;
-
-                    char *name = bu_vls_strdup(&material_ip->name);
-                    struct bu_vls result_str = BU_VLS_INIT_ZERO;
-                    if (analyze_densities_set(density, id, density_double, name, &result_str) < 0) {
-                        bu_vls_printf(&result_str, "Error inserting density %d,%g,%s\n", id, density_double, name);
-                    }
-                    bu_vls_free(&result_str);
-                }
-            }
-        }
-    }
+	// free the old rt_i and set equal to the new one
+	rt_free_rti(ap->a_rt_i);
+	ap->a_rt_i = rtip;
 
     ap->a_hit = hit;
     ap->a_miss = miss;
     ap->a_overlap = overlap;
     ap->a_onehit = 0;
 
-    bu_vls_free(&pbuff_msgs);
-    if (minus_o) {
-	fclose(outfp);
-    }
-
     return 0;		/* no framebuffer needed */
-
-view_init_rtweight_fail:
-    bu_vls_free(&pbuff_msgs);
-    analyze_densities_destroy(density);
-    if (minus_o && outfp) {
-	fclose(outfp);
-    }
-
-    bu_exit(-1, NULL);
 }
 
 

--- a/src/rt/viewweight.c
+++ b/src/rt/viewweight.c
@@ -449,6 +449,11 @@ view_init(struct application *ap, char *file, char *UNUSED(obj), int minus_o, in
 	// we need to be able to read/write to the rt_i
 	struct rt_i *rtip = densities_prep(file, minus_o);
 
+	if (rtip == RTI_NULL) {
+		bu_log("Error: failed to open database %s\n", file);
+		bu_exit(-1, NULL);
+	}
+
 	// copy the old values possibly set in main before view_init was called
 	rtip->rti_space_partition = APP.a_rt_i->rti_space_partition;
     rtip->useair = APP.a_rt_i->useair;


### PR DESCRIPTION
Changes made to gqa and rtweight to allow the use of material objects without an id set. Allows the user flow to look something like this:

>material create material1 test
>material set material1 physical density 1234.1234
>material assign region material1
>gqa region

This way, the user does not have to deal with material_id's at all. Theoretically, the ID could be "invisible" to the user.