### PR TITLE
Art shader updates

### DIFF
--- a/src/art/art.cpp
+++ b/src/art/art.cpp
@@ -151,6 +151,7 @@
 struct application APP;
 struct resource* resources;
 size_t samples = 25;
+size_t light_intensity = 30.0;
 
 extern "C" {
     FILE* outfp = NULL;
@@ -215,6 +216,8 @@ struct bu_structparse view_parse[] = {
     {"%d", 1, "s", 0, BU_STRUCTPARSE_FUNC_NULL, NULL, NULL},
     {"%f", 3, "background", 0, color_hook, NULL, NULL},
     {"%f", 3, "bg", 0, color_hook, NULL, NULL},
+    {"%d", 1, "light_intensity", 0, BU_STRUCTPARSE_FUNC_NULL, NULL, NULL},
+    {"%d", 1, "li", 0, BU_STRUCTPARSE_FUNC_NULL, NULL, NULL},
     {"",	0, (char *)0,	0,	BU_STRUCTPARSE_FUNC_NULL, NULL, NULL }
 };
 
@@ -264,6 +267,8 @@ void init_defaults(void) {
   view_parse[1].sp_offset = bu_byteoffset(samples);
   view_parse[2].sp_offset = bu_byteoffset(background[0]);
   view_parse[3].sp_offset = bu_byteoffset(background[0]);
+  view_parse[4].sp_offset = bu_byteoffset(light_intensity);
+  view_parse[5].sp_offset = bu_byteoffset(light_intensity);
 
   // default output file name
   outputfile = (char*)"art.png";
@@ -276,8 +281,8 @@ void init_defaults(void) {
   // for now, just support -c set samples=x
   // option("", "-o filename", "Render to specified image file (e.g., image.png or image.pix)", 0);
   option("", "-F framebuffer", "Render to a framebuffer (defaults to a window)", 100);
-  option("", "-s #", "Square image size (default: 512 - implies 512x512 image)", 100);
-  option("", "-w # -n #", "Image pixel dimensions as width and height", 100);
+  // option("", "-s #", "Square image size (default: 512 - implies 512x512 image)", 100);
+  // option("", "-w # -n #", "Image pixel dimensions as width and height", 100);
   option("", "-C #/#/#", "Set background image color to R/G/B values (default: 191/204/255)", 0);
   // option("", "-W", "Set background image color to white", 0);
   option("", "-R", "Disable reporting of overlaps", 100);
@@ -725,7 +730,7 @@ asf::auto_release_ptr<asr::Project> build_project(const char* UNUSED(file), cons
 	    "light_intensity",
 	    asr::ParamArray()
 	    .insert("color_space", "srgb")
-	    .insert("multiplier", "30.0"),
+	    .insert("multiplier", light_intensity),
 	    asr::ColorValueArray(3, LightRadiance)));
 
     // Create a point light called "light" and insert it into the assembly.

--- a/src/art/art.cpp
+++ b/src/art/art.cpp
@@ -369,11 +369,11 @@ int register_region(struct db_tree_state* tsp __attribute__((unused)),
                .insert("object_path", name_char)
                .insert("object_count", objc)
                .insert("minX", min[X])
-               .insert("minY", min[Y])
-               .insert("minZ", min[Z])
+               .insert("minY", min[Z])
+               .insert("minZ", min[Y])
                .insert("maxX", max[X])
-               .insert("maxY", max[Y])
-               .insert("maxZ", max[Z]);
+               .insert("maxY", max[Z])
+               .insert("maxZ", max[Y]);
 
 
   asf::auto_release_ptr<renderer::Object> brlcad_object(
@@ -815,7 +815,7 @@ asf::auto_release_ptr<asr::Project> build_project(const char* UNUSED(file), cons
     camera->transform_sequence().set_transform(
 	0.0f,
 	asf::Transformd::from_local_to_parent(
-	    asf::Matrix4d::make_translation(asf::Vector3d(eye_model[0], eye_model[1], eye_model[2])) * /* camera location */
+	    asf::Matrix4d::make_translation(asf::Vector3d(eye_model[0], eye_model[2], -eye_model[1])) * /* camera location */
 	    asf::Matrix4d::make_rotation(asf::Vector3d(0.0, 1.0, 0.0), asf::deg_to_rad(azimuth - 270)) * /* azimuth */
 	    asf::Matrix4d::make_rotation(asf::Vector3d(1.0, 0.0, 0.0), asf::deg_to_rad(-elevation)) /* elevation */
 	));

--- a/src/art/art.cpp
+++ b/src/art/art.cpp
@@ -352,7 +352,7 @@ int register_region(struct db_tree_state* tsp __attribute__((unused)),
   point_t min;
   point_t max;
   // int ret = ged_get_obj_bounds(ged, 1, (const char**)&name, 1, min, max);
-  int ret = ged_get_obj_bounds(ged, 1, (const char**)name_char, 1, min, max);
+  int ret = ged_get_obj_bounds(ged, 1, (const char**)&name_char, 1, min, max);
 
   bu_log("ged: %i | min: %f %f %f | max: %f %f %f\n", ret, V3ARGS(min), V3ARGS(max));
 
@@ -366,14 +366,14 @@ int register_region(struct db_tree_state* tsp __attribute__((unused)),
   */
   renderer::ParamArray geometry_parameters = asr::ParamArray()
                .insert("database_path", name)
-               // .insert("database_path", name_char)
+               .insert("object_path", name_char)
                .insert("object_count", objc)
                .insert("minX", min[X])
-               .insert("minY", min[Z])
-               .insert("minZ", min[Y])
+               .insert("minY", min[Y])
+               .insert("minZ", min[Z])
                .insert("maxX", max[X])
-               .insert("maxY", max[Z])
-               .insert("maxZ", max[Y]);
+               .insert("maxY", max[Y])
+               .insert("maxZ", max[Z]);
 
 
   asf::auto_release_ptr<renderer::Object> brlcad_object(
@@ -719,6 +719,7 @@ asf::auto_release_ptr<asr::Project> build_project(const char* UNUSED(file), cons
 
     // Create a color called "light_intensity" and insert it into the assembly.
     static const float LightRadiance[] = { 1.0f, 1.0f, 1.0f };
+    // FIXME
     assembly->colors().insert(
 	asr::ColorEntityFactory::create(
 	    "light_intensity",
@@ -814,10 +815,15 @@ asf::auto_release_ptr<asr::Project> build_project(const char* UNUSED(file), cons
     camera->transform_sequence().set_transform(
 	0.0f,
 	asf::Transformd::from_local_to_parent(
-	    asf::Matrix4d::make_translation(asf::Vector3d(eye_model[0], eye_model[2], -eye_model[1])) * /* camera location */
+	    asf::Matrix4d::make_translation(asf::Vector3d(eye_model[0], eye_model[1], eye_model[2])) * /* camera location */
 	    asf::Matrix4d::make_rotation(asf::Vector3d(0.0, 1.0, 0.0), asf::deg_to_rad(azimuth - 270)) * /* azimuth */
 	    asf::Matrix4d::make_rotation(asf::Vector3d(1.0, 0.0, 0.0), asf::deg_to_rad(-elevation)) /* elevation */
 	));
+  // camera->transform_sequence().set_transform(
+  //     0.0f,
+  //     asf::Transformd::from_local_to_parent(
+  //         asf::Matrix4d::make_rotation(asf::Vector3d(1.0, 0.0, 0.0), asf::deg_to_rad(-20.0)) *
+  //         asf::Matrix4d::make_translation(asf::Vector3d(0.0, 0.8, 11.0))));
 
     // Bind the camera to the scene.
     scene->cameras().insert(camera);

--- a/src/art/art.cpp
+++ b/src/art/art.cpp
@@ -374,11 +374,11 @@ int register_region(struct db_tree_state* tsp __attribute__((unused)),
                .insert("object_path", name_char)
                .insert("object_count", objc)
                .insert("minX", min[X])
-               .insert("minY", min[Z])
-               .insert("minZ", min[Y])
+               .insert("minY", min[Y])
+               .insert("minZ", min[Z])
                .insert("maxX", max[X])
-               .insert("maxY", max[Z])
-               .insert("maxZ", max[Y]);
+               .insert("maxY", max[Y])
+               .insert("maxZ", max[Z]);
 
 
   asf::auto_release_ptr<renderer::Object> brlcad_object(
@@ -820,7 +820,7 @@ asf::auto_release_ptr<asr::Project> build_project(const char* UNUSED(file), cons
     camera->transform_sequence().set_transform(
 	0.0f,
 	asf::Transformd::from_local_to_parent(
-	    asf::Matrix4d::make_translation(asf::Vector3d(eye_model[0], eye_model[2], -eye_model[1])) * /* camera location */
+	    asf::Matrix4d::make_translation(asf::Vector3d(eye_model[0], eye_model[1], eye_model[2])) * /* camera location */
 	    asf::Matrix4d::make_rotation(asf::Vector3d(0.0, 1.0, 0.0), asf::deg_to_rad(azimuth - 270)) * /* azimuth */
 	    asf::Matrix4d::make_rotation(asf::Vector3d(1.0, 0.0, 0.0), asf::deg_to_rad(-elevation)) /* elevation */
 	));

--- a/src/art/art.h
+++ b/src/art/art.h
@@ -120,6 +120,7 @@ class APPLESEED_DLL_EXPORT BrlcadObject : public asr::ProceduralObject
 public:
     BrlcadObject(const char* name, const asr::ParamArray& params);
     BrlcadObject(const char* name, const asr::ParamArray& params, struct application* ap, struct resource* resources);
+    std::string name;
     void release() override;
     const char* get_model() const override;
     bool on_frame_begin(const asr::Project& project, const asr::BaseGroup* parent, asr::OnFrameBeginRecorder& recorder, asf::IAbortSwitch* abort_switch) override;

--- a/src/art/brlcadplugin.cpp
+++ b/src/art/brlcadplugin.cpp
@@ -194,6 +194,9 @@ BrlcadObject::BrlcadObject(
     VSET(max, m_params.get_required<double>("maxX"), m_params.get_required<double>("maxY"), m_params.get_required<double>("maxZ"));
     // VMOVE(min, ap->a_uvec);
     // VMOVE(max, ap->a_vvec);
+
+    fprintf(output, "appleseed const: Local Bounding Box: (%f, %f, %f) , (%f, %f, %f)\n", V3ARGS(min), V3ARGS(max));
+    fflush(output);
 }
 
 
@@ -207,8 +210,18 @@ BrlcadObject:: BrlcadObject(
     this->ap = p_ap;
     this->rtip = p_ap->a_rt_i;
     this->resources = p_resources;
-    VMOVE(this->min, ap->a_uvec);
-    VMOVE(this->max, ap->a_vvec);
+    // VMOVE(this->min, ap->a_uvec);
+    // VMOVE(this->max, ap->a_vvec);
+
+    VSET(min, m_params.get_required<double>("minX"), m_params.get_required<double>("minY"), m_params.get_required<double>("minZ"));
+    VSET(max, m_params.get_required<double>("maxX"), m_params.get_required<double>("maxY"), m_params.get_required<double>("maxZ"));
+
+
+    // VSETALL(ap->a_uvec, 0);
+    // VSETALL(ap->a_vvec, 0);
+
+    fprintf(output, "art.cpp const: Local Bounding Box: (%f, %f, %f) , (%f, %f, %f)\n", V3ARGS(min), V3ARGS(max));
+    fflush(output);
 }
 
 

--- a/src/art/brlcadplugin.cpp
+++ b/src/art/brlcadplugin.cpp
@@ -131,6 +131,7 @@
 #include "vmath.h"
 #include "raytrace.h"
 #include "brlcadplugin.h"
+#include "bu/str.h"
 
 namespace asf = foundation;
 namespace asr = renderer;
@@ -139,19 +140,30 @@ FILE* output = fopen("print_statements.txt", "wb");
 
 /* brlcad raytrace hit callback */
 int
-brlcad_hit(struct application* UNUSED(ap), struct partition* PartHeadp, struct seg* UNUSED(segs))
+brlcad_hit(struct application* ap, struct partition* PartHeadp, struct seg* UNUSED(segs))
 {
     struct partition* pp;
     struct hit* hitp;
     struct soltab* stp;
 
+    // struct curvature cur = RT_CURVATURE_INIT_ZERO;
+
     //point_t pt;
     vect_t inormal;
+
+    // vect_t onormal;
 
     pp = PartHeadp->pt_forw;
 
     /* entry hit point, so we type less */
     hitp = pp->pt_inhit;
+
+    // fprintf(output, "names: %s | %s\n", (const char*)ap->a_uptr, pp->pt_regionp->reg_name);
+    // fflush(output);
+
+    if(!BU_STR_EQUAL((const char*)ap->a_uptr, pp->pt_regionp->reg_name)) {
+      return 0;
+    }
 
     /* construct the actual (entry) hit-point from the ray and the
 	* distance to the intersection point (i.e., the 't' value).
@@ -168,8 +180,8 @@ brlcad_hit(struct application* UNUSED(ap), struct partition* PartHeadp, struct s
     RT_HIT_NORMAL(inormal, hitp, stp, &(ap->a_ray), pp->pt_inflip);
 
     brlcad_ray_info.normal[0] = inormal[0];
-    brlcad_ray_info.normal[1] = inormal[2];
-    brlcad_ray_info.normal[2] = -inormal[1];
+    brlcad_ray_info.normal[1] = inormal[1];
+    brlcad_ray_info.normal[2] = inormal[2];
 
     return 1;
 }
@@ -195,6 +207,7 @@ BrlcadObject::BrlcadObject(
     // VMOVE(min, ap->a_uvec);
     // VMOVE(max, ap->a_vvec);
 
+    this->name = m_params.get_required<std::string>("object_path");
     fprintf(output, "appleseed const: Local Bounding Box: (%f, %f, %f) , (%f, %f, %f)\n", V3ARGS(min), V3ARGS(max));
     fflush(output);
 }
@@ -213,6 +226,7 @@ BrlcadObject:: BrlcadObject(
     // VMOVE(this->min, ap->a_uvec);
     // VMOVE(this->max, ap->a_vvec);
 
+    this->name = m_params.get_required<std::string>("object_path");
     VSET(min, m_params.get_required<double>("minX"), m_params.get_required<double>("minY"), m_params.get_required<double>("minZ"));
     VSET(max, m_params.get_required<double>("maxX"), m_params.get_required<double>("maxY"), m_params.get_required<double>("maxZ"));
 
@@ -308,8 +322,10 @@ BrlcadObject::intersect(
     ap->a_resource = &resources[cpu];
 
     const asf::Vector3d dir = asf::normalize(ray.m_dir);
-    VSET(ap->a_ray.r_dir, dir[0], -dir[2], dir[1]);
-    VSET(ap->a_ray.r_pt, ray.m_org[0], -ray.m_org[2], ray.m_org[1]);
+    VSET(ap->a_ray.r_dir, dir[0], dir[1], dir[2]);
+    VSET(ap->a_ray.r_pt, ray.m_org[0], ray.m_org[1], ray.m_org[2]);
+
+    ap->a_uptr = (void*)this->name.c_str();
 
     if (rt_shootray(ap) == 0)
     {
@@ -323,6 +339,12 @@ BrlcadObject::intersect(
 
 	const asf::Vector3d n = asf::normalize(brlcad_ray_info.normal);
 	result.m_geometric_normal = n;
+
+  // const asf::Vector3d n_flip (n[0], n[2], n[1]);
+  // double temp;
+  // temp = n_flip[2];
+  // n_flip.set(2) = n_flip[1];
+  // n_flip.set(1) = temp;
 	result.m_shading_normal = n;
 
 	// const asf::Vector3f p(brlcad_ray_info.normal * m_rcp_radius);
@@ -345,8 +367,8 @@ BrlcadObject::intersect(const asr::ShadingRay& ray) const
     ap->a_resource = &resources[cpu];
 
     const asf::Vector3d dir = asf::normalize(ray.m_dir);
-    VSET(ap->a_ray.r_dir, dir[0], -dir[2], dir[1]);
-    VSET(ap->a_ray.r_pt, ray.m_org[0], -ray.m_org[2], ray.m_org[1]);
+    VSET(ap->a_ray.r_dir, dir[0], dir[1], dir[2]);
+    VSET(ap->a_ray.r_pt, ray.m_org[0], ray.m_org[1], ray.m_org[2]);
 
     return (rt_shootray(ap) == 1);
 }

--- a/src/art/brlcadplugin.cpp
+++ b/src/art/brlcadplugin.cpp
@@ -180,8 +180,8 @@ brlcad_hit(struct application* ap, struct partition* PartHeadp, struct seg* UNUS
     RT_HIT_NORMAL(inormal, hitp, stp, &(ap->a_ray), pp->pt_inflip);
 
     brlcad_ray_info.normal[0] = inormal[0];
-    brlcad_ray_info.normal[1] = inormal[1];
-    brlcad_ray_info.normal[2] = inormal[2];
+    brlcad_ray_info.normal[1] = inormal[2];
+    brlcad_ray_info.normal[2] = -inormal[1];
 
     return 1;
 }
@@ -322,8 +322,8 @@ BrlcadObject::intersect(
     ap->a_resource = &resources[cpu];
 
     const asf::Vector3d dir = asf::normalize(ray.m_dir);
-    VSET(ap->a_ray.r_dir, dir[0], dir[1], dir[2]);
-    VSET(ap->a_ray.r_pt, ray.m_org[0], ray.m_org[1], ray.m_org[2]);
+    VSET(ap->a_ray.r_dir, dir[0], -dir[2], dir[1]);
+    VSET(ap->a_ray.r_pt, ray.m_org[0], -ray.m_org[2], ray.m_org[1]);
 
     ap->a_uptr = (void*)this->name.c_str();
 
@@ -367,8 +367,8 @@ BrlcadObject::intersect(const asr::ShadingRay& ray) const
     ap->a_resource = &resources[cpu];
 
     const asf::Vector3d dir = asf::normalize(ray.m_dir);
-    VSET(ap->a_ray.r_dir, dir[0], dir[1], dir[2]);
-    VSET(ap->a_ray.r_pt, ray.m_org[0], ray.m_org[1], ray.m_org[2]);
+    VSET(ap->a_ray.r_dir, dir[0], -dir[2], dir[1]);
+    VSET(ap->a_ray.r_pt, ray.m_org[0], -ray.m_org[2], ray.m_org[1]);
 
     return (rt_shootray(ap) == 1);
 }

--- a/src/art/brlcadplugin.cpp
+++ b/src/art/brlcadplugin.cpp
@@ -180,8 +180,8 @@ brlcad_hit(struct application* ap, struct partition* PartHeadp, struct seg* UNUS
     RT_HIT_NORMAL(inormal, hitp, stp, &(ap->a_ray), pp->pt_inflip);
 
     brlcad_ray_info.normal[0] = inormal[0];
-    brlcad_ray_info.normal[1] = inormal[2];
-    brlcad_ray_info.normal[2] = -inormal[1];
+    brlcad_ray_info.normal[1] = inormal[1];
+    brlcad_ray_info.normal[2] = inormal[2];
 
     return 1;
 }
@@ -322,8 +322,8 @@ BrlcadObject::intersect(
     ap->a_resource = &resources[cpu];
 
     const asf::Vector3d dir = asf::normalize(ray.m_dir);
-    VSET(ap->a_ray.r_dir, dir[0], -dir[2], dir[1]);
-    VSET(ap->a_ray.r_pt, ray.m_org[0], -ray.m_org[2], ray.m_org[1]);
+    VSET(ap->a_ray.r_dir, dir[0], dir[1], dir[2]);
+    VSET(ap->a_ray.r_pt, ray.m_org[0], ray.m_org[1], ray.m_org[2]);
 
     ap->a_uptr = (void*)this->name.c_str();
 
@@ -367,8 +367,8 @@ BrlcadObject::intersect(const asr::ShadingRay& ray) const
     ap->a_resource = &resources[cpu];
 
     const asf::Vector3d dir = asf::normalize(ray.m_dir);
-    VSET(ap->a_ray.r_dir, dir[0], -dir[2], dir[1]);
-    VSET(ap->a_ray.r_pt, ray.m_org[0], -ray.m_org[2], ray.m_org[1]);
+    VSET(ap->a_ray.r_dir, dir[0], dir[1], dir[2]);
+    VSET(ap->a_ray.r_pt, ray.m_org[0], ray.m_org[1], ray.m_org[2]);
 
     return (rt_shootray(ap) == 1);
 }


### PR DESCRIPTION
Art pulls correct shaders from material optical OSL key value
Hit function is updated to compare region name to ensure correct hit calculations (this is done with string comparison which should be optimized at some point) 
Matrices are reverted from y, -z flip since this causes issues. This means the scene is rendered correctly - but rotated